### PR TITLE
Changed schedule time duration and string encoding

### DIFF
--- a/excorporate-org.el
+++ b/excorporate-org.el
@@ -60,22 +60,30 @@ SUBJECT is the meeting's subject, START-TIME and END-TIME are the
 meeting's start and end times in the same format as is returned
 by `current-time'."
   (let* ((now (current-time))
-	 (keyword (if (time-less-p now end-time)
-		      "TODO"
-		    "DONE")))
-    (insert (format "** %s %s\n" keyword subject))
-    (org-schedule nil (format-time-string "<%Y-%m-%d %a %H:%M>"
-					  start-time))
-    (forward-line -1)
-    (end-of-line)
-    (insert  "--" (format-time-string "<%Y-%m-%d %a %H:%M>" end-time))
+         (start-date (format-time-string "%Y-%m-%d" start-time))
+         (end-date   (format-time-string "%Y-%m-%d" end-time))
+         (keyword (if (time-less-p now end-time)
+                      "TODO"
+                    "DONE")))
+    (insert (format "** %s %s\n" keyword
+                    (decode-coding-string subject 'utf-8)))
+    (if (string= start-date end-date)
+        (org-schedule nil (concat (format-time-string "<%Y-%m-%d %a %H:%M" start-time)
+                                  (format-time-string "-%H:%M>" end-time)))
+      (progn
+        (org-schedule nil (format-time-string "<%Y-%m-%d %a %H:%M>"
+                                              start-time))
+        (forward-line -1)
+        (end-of-line)
+        (insert  "--" (format-time-string "<%Y-%m-%d %a %H:%M>" end-time))))
     (forward-line)
     (org-insert-time-stamp (current-time) t t "+ Retrieved " "\n")))
 
 (defun exco-org-insert-invitees (invitees)
   "Parse and insert a list of invitees, INVITEES."
   (dolist (invitee invitees)
-    (insert (format "  + %s\n" invitee))))
+    (insert (format "  + %s\n"
+                    (decode-coding-string invitee 'utf-8)))))
 
 (defun exco-org-insert-headline (identifier month day year)
   "Insert Org headline for IDENTIFIER on date MONTH DAY YEAR."
@@ -96,7 +104,8 @@ are the requested participants."
   (exco-org-insert-meeting-headline subject start end)
   (insert (format "+ Duration: %d minutes\n"
 		  (round (/ (float-time (time-subtract end start)) 60.0))))
-  (insert (format "+ Location: %s\n" location))
+  (insert (format "+ Location: %s\n" ;;location))
+                  (decode-coding-string location 'utf-8)))
   (when main-invitees
     (insert "+ Invitees:\n")
     (exco-org-insert-invitees main-invitees))


### PR DESCRIPTION
1. Change schedule for time duration from <>--<> to <Ymd HM-HM>
2. Merge utf8 string encoding from frtmelody (adde596)